### PR TITLE
feat: configurable servers

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -187,6 +187,30 @@ jobs:
           -e SERVER_COUNT=foo \
           "${{ env.IMAGE_NAME }}"
 
+      - name: Run Docker Image with Invalid old server params
+        timeout-minutes: 1
+        id: test-validation-old-server-params
+        continue-on-error: true
+        run: |
+          ! docker run \
+          -e STRATEGY=PERCENTAGE \
+          -e OLD_DOMAIN=haproxy.com:443 -e NEW_DOMAIN=apache.org:443 \
+          -e SERVER_PARAMS_OLD=bar \
+          -e COOKIE_PERCENTAGE_NAME=my_app \
+          "${{ env.IMAGE_NAME }}"
+
+      - name: Run Docker Image with Invalid new server params
+        timeout-minutes: 1
+        id: test-validation-new-server-params
+        continue-on-error: true
+        run: |
+          ! docker run \
+          -e STRATEGY=PERCENTAGE \
+          -e OLD_DOMAIN=haproxy.com:443 -e NEW_DOMAIN=apache.org:443 \
+          -e SERVER_PARAMS_NEW=bar \
+          -e COOKIE_PERCENTAGE_NAME=my_app \
+          "${{ env.IMAGE_NAME }}"
+
       - name: Check for failures
         if: always()
         env:

--- a/README.md
+++ b/README.md
@@ -45,6 +45,23 @@ how much traffic should be routed to the new application
 as we are using DNS Resolver we try to create a server for each IP address we get back from the DNS query. 
 This is the maximum amount of servers we will create. 
 
+### SERVER_PARAMS_NEW (optional, default=check)
+>know what you do!
+
+here you can override the server parameters for the new servers
+see [here](https://www.haproxy.com/documentation/haproxy-configuration-manual/latest/#5)
+
+### SERVER_PARAMS_OLD (optional, default=check)
+>know what you do!
+
+here you can override the server parameters for the old servers
+see [here](https://www.haproxy.com/documentation/haproxy-configuration-manual/latest/#5)
+
+### REWRITE_HOST_NEW (optional, default=0)
+wether to rewrite the host header to the new domain or not
+
+### REWRITE_HOST_OLD (optional, default=0)
+wether to rewrite the host header to the old domain or not
 
 ## Local Testing
 

--- a/haproxy.cfg
+++ b/haproxy.cfg
@@ -11,6 +11,10 @@ global
   presetenv PERCENTAGE_NEW "0"
   presetenv PERCENTAGE_OLD "100"
   presetenv SERVER_COUNT "5"
+  presetenv SERVER_PARAMS_OLD "check"
+  presetenv SERVER_PARAMS_NEW "check"
+  presetenv REWRITE_HOST_NEW "0"
+  presetenv REWRITE_HOST_OLD "0"
 
   # we source them from the environment here to actually typecheck them
   set-var proc.percentage_new int("${PERCENTAGE_NEW}")
@@ -25,7 +29,6 @@ defaults
   timeout client 1m
   timeout server 1m
   mode http
-  default-server  check
   default-server  resolvers dns
   default-server  resolve-prefer ipv4
   default-server  init-addr last,libc,none
@@ -53,32 +56,34 @@ frontend http-in
   use_backend cookie_strategy if routing_strategy_cookie is_new_cookie
 
 backend old_domain
-  http-response set-header X-Proxy-Flow route-to-legacy
-  option tcp-check
   balance leastconn
+  http-response set-header X-Proxy-Flow route-to-legacy
+  http-request set-header Host "$OLD_DOMAIN" if { env(REWRITE_HOST_OLD) -m bool }
 
-  server-template default_old "$SERVER_COUNT" "$OLD_DOMAIN"
+  server-template default_old "$SERVER_COUNT" "$OLD_DOMAIN" "$SERVER_PARAMS_OLD"
 
 backend percentage_strategy
   http-response set-header X-Proxy-Flow route-to-percentage
-  option tcp-check
   # https://www.haproxy.com/documentation/haproxy-configuration-manual/latest/#4.2-balance
   balance static-rr
 
   cookie "$COOKIE_PERCENTAGE_NAME" insert indirect
 
+  http-request set-header Host "$NEW_DOMAIN" if { env(REWRITE_HOST_NEW) -m bool && srv_id(new_domain_percentage) }
+  http-request set-header Host "$OLD_DOMAIN" if { env(REWRITE_HOST_OLD) -m bool && srv_id(old_domain_percentage) }
+
   # old domain
-  server-template old_domain_percentage "$SERVER_COUNT" "$OLD_DOMAIN" cookie "old_domain_$PERCENTAGE_OLD" weight "$PERCENTAGE_OLD"
+  server-template old_domain_percentage "$SERVER_COUNT" "$OLD_DOMAIN" cookie "old_domain_$PERCENTAGE_OLD" weight "$PERCENTAGE_OLD" "$SERVER_PARAMS_OLD"
 
   # new domain
-  server-template new_domain_percentage "$SERVER_COUNT" "$NEW_DOMAIN" cookie "new_domain_$PERCENTAGE_NEW" weight "$PERCENTAGE_NEW"
+  server-template new_domain_percentage "$SERVER_COUNT" "$NEW_DOMAIN" cookie "new_domain_$PERCENTAGE_NEW" weight "$PERCENTAGE_NEW" "$SERVER_PARAMS_NEW"
 
 backend cookie_strategy
   balance leastconn
   http-response set-header X-Proxy-Flow route-to-new
-  option tcp-check
+  http-request set-header Host "$NEW_DOMAIN" if { env(REWRITE_HOST_NEW) -m bool }
 
-  server-template default_new "$SERVER_COUNT" "$NEW_DOMAIN"
+  server-template default_new "$SERVER_COUNT" "$NEW_DOMAIN" "$SERVER_PARAMS_NEW"
 
 resolvers dns
   parse-resolv-conf


### PR DESCRIPTION
adds the ability to override server parameters for the OLD or NEW servers through `SERVER_PARAMS_NEW` or ?`SERVER_PARAMS_OLD` (optional, default=check) (to e.g. disable healthchecks)

adds the ability to rewrite the host header for the OLD or NEW server through `REWRITE_HOST_NEW` or `REWRITE_HOST_OLD` (optional, default=0)
